### PR TITLE
RDKEMW-2489: remove workaround fixes on Middleware

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="f865b08b086a7d6bcfa5e393497abae8288acc51">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="9a6c9a7d3c46610f51412e1b0dc070353a1f2f6d">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Reason for change: Remove workaround that are not used.
Test Procedure: None
Risks: Low
Priority: P1
Signed-off-by: snazee925@cable.comcast.com