### PR TITLE
RDKEMW-2175 : Run player within jsruntime plugin via static load of a…

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -1,7 +1,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="refs/tags/1.0.0">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="befb0ebb802ac179a4579ecca20343236623013f">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
@@ -10,7 +10,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="refs/tags/1.0.0">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="a16ed65bf7b7ac3663f4a482dac3ad9fce7e371f">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
…ampjsbindings

Reason for change: Updating latest revision of meta-rdk-video and generic-support.
Test Procedure: build and playback should be successful.
Risks: low
Priority: P2