### PR TITLE
RDKOSS-214 - Auto PR for rdkcentral/meta-rdk 10

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='utf-8'?>
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
@@ -5,7 +6,7 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
-  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="refs/tags/1.0.0">
+  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="9288de75baca025fd5b51e1e95b018c0f1fe8bdf">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_RDK" />
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>


### PR DESCRIPTION
Details: Reason for change: As openssl is upgraded from 3.0.5 to 3.0.15, preferred version 3.0.5 is not available and bitbake picks openssl 1.1.1l from meta-rdk-oss-reference based on layer priority.


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk, Merge Commit SHA: 9288de75baca025fd5b51e1e95b018c0f1fe8bdf
