### PR TITLE
RDKEMW-2925: rdkshell-Remove workaround fixes on middleware

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="9a6c9a7d3c46610f51412e1b0dc070353a1f2f6d">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="bfefe8b0da11305390faeef4cf07dad8a0c014e3">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Reason for change: rdkshell-Remove workaround fixes on middleware Test Procedure: None
Risks: Low
Priority: P1
Signed-off-by:mkooda197@cable.comcast.com