### PR TITLE
RDKEMW-2915: Remove workaround for qtbase

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="bfefe8b0da11305390faeef4cf07dad8a0c014e3">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="f0e2dbda635cca08c95252cf25ffa422a10cecfb">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Reason for change: Remove workaround for qtbase
Test Procedure: None
Risks: Low
Priority: P1
Signed-off-by:mkooda197@cable.comcast.com