### PR TITLE
RDK-56155 - Auto PR for rdkcentral/meta-middleware-generic-support 79

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="91fecc15f32a489b2c0ca73c78d3d34fe50889aa">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="20b5759a67d2c39e8c21ecb06a024398599a1bd5">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="26997607a2283d514f53434cefde39ef5cfa98a7">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="fa9819762ff59483219d516a640c2ca69cbbda9c">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: Bump rdkservices-apis to 1.3.0
Risk: Medium
Priority: P1

Change-Id: Icfe2f5fe253778ac045ad5346554143722ea4796


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: 20b5759a67d2c39e8c21ecb06a024398599a1bd5
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: fa9819762ff59483219d516a640c2ca69cbbda9c
