### PR TITLE
RDKEMW-3192 : Pandora does not resume playback

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="5a481b0689f78913d20d2f9e463b58d5981d8e21">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="ec7bc7370dd6dacfa0fa7ab352ad169596f2cd29">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Reason for change: Revert for change brought in webkit downstream calling play() during a seek() is allowed by the spec. And the play event should be fired even if the seek hasn't completed. Test Procedure: Check ticket
Risks: NA