### PR TITLE
RDKEMW-2318: Nothing PROVIDES 'virtual/lib32-vendor-closedcaption-hal for aamp component

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="f0e2dbda635cca08c95252cf25ffa422a10cecfb">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="cb8ff69f4ca381df956700ed62483ee2608794f8">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Reason for change: removing workaround for aamp
Test Procedure: None
Risks: Low
Priority: P1
Signed-off-by: nejumathoppil_nazar@comcast.com