### PR TITLE
RDKEMW-3192 - Auto PR for rdkcentral/meta-rdk-video 87

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="54eb4ee3730c5059a6e56f4338f87a7454bf1e30">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="4b9a1c1d9a3d837540a59668f28367831d0ece41">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: Revert for change brought in webkit downstream calling play() during a seek() is allowed by the spec. And the play event should be fired even if the seek hasn't completed. Test Procedure: Check ticket
Risks: NA


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 4b9a1c1d9a3d837540a59668f28367831d0ece41
