### PR TITLE
RDKEMW-3311 - NetworkManager Thunder Plugin - Systemd Service cleanup

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="4ed8d6b756238a1cb1112bf2ad3b722aae2a2c81">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="280dbcaf8f6c3d744ad17697a467d3316abea889">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Reason for change: Moved the wpeframework-networkmanager.service from meta-rdk-comcast-video to here
Test Procedure: check the command "systemctl status NetworkManager"
Risks: Medium
Priority: P1
Signed-off-by: Gururaaja ESR <gururaja_erodesriranganramlingham@comcast.com>