### PR TITLE
RDKEMW-2915: Remove workaround for qtbase

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="57dd7ffa15bcce7efe9d3e6d2669c6a7c65f0b35">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="39a15ac38957119c883fef5df54c08a0090a13df">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Reason for change: Remove workaround for qtbase
Test Procedure: None
Risks: Low
Priority: P1
Signed-off-by:mkooda197@cable.comcast.com