### PR TITLE
RDKOSS-228 - Auto PR for rdkcentral/meta-rdk 75

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -6,7 +6,7 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
-  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="c26977139bb8abe55da28ce06d9d4f8b223e2636">
+  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="3d5f474613d846cc4bc14bc6328e32b734a9b9c3">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_RDK" />
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>


### PR DESCRIPTION
Details: Reason for change:  Updated recipes to use relative paths instead of absolute paths. 
The `MANIFEST_PATH_*` variables within the `xmidt-agent.bb` and `rdksysctl.bb` are modified to use relative paths.
Test Procedure:  Build image and verify that these components are not rebuilt when sstate mirrors are available.
Risks: Low


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk, Merge Commit SHA: 3d5f474613d846cc4bc14bc6328e32b734a9b9c3
