### PR TITLE
RDKOSS-228 - Auto PR for rdkcentral/meta-rdk-video 258

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="20c15ef667cbf3af7b6cfa1d6a305d34cfe55f25">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="92845f73cada36cf1ee382279f79d63570affb9d">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: Updated recipes to use relative paths instead of absolute paths.
* The `MANIFEST_PATH_*` variables within the `bootversion-loader.bb`, `uwebsockets_git.bb`,  `wlan-p2p` and `rdknativescripts.bb` are modified to use relative paths.
* `thunderstartupservices.bb` recipe was updated to modify the `0002-displaysettings-tv-deps.patch` inorder to use source dir itself instead of specifying patch dir separately.

Test Procedure: Build image and verify that these components are not rebuilt when sstate mirrors are available.
Risks: Low



List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 92845f73cada36cf1ee382279f79d63570affb9d
