### PR TITLE
RDK-56570 - Auto PR for rdkcentral/meta-middleware-generic-support 346

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="0ac7c36259d34214ac252161117b18440b340363">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="10f541106e3434779fea4c55e5c9eab2255b2bec">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change : 
1) Invoke volatile-bind framework in middleware packagegroup
2) Remove dependency of vaoltile-binds recipe
Test Procedure : Successful build, Check the ticket
signed-off-by : Sindhuja <Sindhuja_Muthukrishnan@comcast.com>


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: 10f541106e3434779fea4c55e5c9eab2255b2bec
