### PR TITLE
RDKEMW-4169 - Auto PR for rdkcentral/meta-rdk-video 348

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="908633b72ad3de1bb3187ac31c0690739369568d">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="1e00f9b5da8af725d03116aac036e1f5607572b7">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: wpeframework/ctrlm
should stop before secure folder to prevent
fs corruption and umount failure.
Test Procedure: Check system.log.
Risks: None


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 1e00f9b5da8af725d03116aac036e1f5607572b7
