### PR TITLE
RDKEMW-4522 - Auto PR for rdkcentral/meta-rdk-video 498

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="4434937587270c907f8a390815dd55d6560898e1">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="2b90483936a530b2f82b503f2c912297219275d8">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="1c5d535c62ccbd692fde50c9574b5f6485f61296">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="fa2099f7b8abfbfb25c0601b7d0d497444c8abd8">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: RDKEMW-4522: Added the p2p_udhcpc script for Miracast P2P Client Mode

Reason for change: Earlier p2p_udhcpc script available in netsrvmgr which is deprecated. Hence moving it to here.
Test Procedure: Miracast should work in P2P client mode
Risks: None
Priority: P1

Signed-off-by: yuvaramachandran_gurusamy <yuvaramachandran_gurusamy@comcast.com>


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: fa2099f7b8abfbfb25c0601b7d0d497444c8abd8
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: 2b90483936a530b2f82b503f2c912297219275d8
