### PR TITLE
RDKEMW-4220: update meta-rdk-video for thunder crash fix

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -10,7 +10,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="refs/tags/1.1.1-community">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="3a4d7533786e1052b1db0b4a77c453ef452c6d1c">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Reason for Change: Intake the meta-rdk-video SHA which has the following fix.
RDKEMW-4220: Fix wpeframework crash on reactivating plugin and power state change https://github.com/rdkcentral/meta-rdk-video/commit/3a4d7533786e1052b1db0b4a77c453ef452c6d1c