### PR TITLE
RDKEMW-4363 - Auto PR for rdkcentral/meta-rdk-video 460

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="2b90483936a530b2f82b503f2c912297219275d8">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="e9c34a953a05bf3f4246d41692b5fc1fd7526dec">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="12fe813b106226c9c7a62e0ee059fab1041153bd">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="dd871fa3618f6361f2dc6be96ecb2474e9b6acc9">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: The common functionality in those libraries have been consolidated and so the subttxrend-app build must now depend on subttxrend-ctrl instead of the individual subtec libraries.
Test Procedure: Build and Regression Test. No new functionality.

Change-Id: I179eaa4c8475474e3eb2f99b817b18a7c9573501


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: dd871fa3618f6361f2dc6be96ecb2474e9b6acc9
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: e9c34a953a05bf3f4246d41692b5fc1fd7526dec
