### PR TITLE
RDKEMW-3466 - Auto PR for rdkcentral/meta-rdk-video 564

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="2f5903f826e1449a0a0e167711ebce37f8b046b9">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="1657e898d57975027d6bc5f984196eceac71ec03">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details:     Reason for change: LibUV was not linked to uwebsocket
    Test Procedure: build should be successful.
    Risks: low
    Priority: P2


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 1657e898d57975027d6bc5f984196eceac71ec03
