### PR TITLE
RDKEMW-3788 - Auto PR for rdkcentral/meta-rdk-video 669

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="2923164ce4f5ba14e25454bfc1a8ec54d54c5074">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="08f3e800d107b732e36530b62b2ea6cabe090585">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="6fe4d23a89ca0c6e973acbcafeb8a0b5ab0fcf1e">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="3d004077dbd51e468f84c8bf37099b62e5bb185a">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: missing WAI support in RDK-E
Test Procedure: described in the ticket
Implements: code changes in AuthService and DeviceProvisioning
Risks: No
Source: COMCAST
License: Apache-2.0
Upstream-Status: Pending


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: 08f3e800d107b732e36530b62b2ea6cabe090585
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 3d004077dbd51e468f84c8bf37099b62e5bb185a
