### PR TITLE
RDKEMW-5238 - Auto PR for rdkcentral/meta-rdk-video 711

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="bf3bd0728e957cdccce0a66369726a6a80469ede">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="f6de2b115edfcad12464eccb7ba0bc23029581f2">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: Realtek VA requires the installation path for DAC Apps to be /tmp/data so adding variable that can be configured from product layer

Test Procedure: Build and verify.

Risks: Low


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: f6de2b115edfcad12464eccb7ba0bc23029581f2
- Repository: rdkcentral/LISA, Merge Commit SHA: ced76740507d39e5078e9e1e30936cb7addff438
