### PR TITLE
RDKTV-34129 - Auto PR for rdkcentral/meta-rdk 143

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -6,7 +6,7 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
-  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="38042d2901c6823d9c4087bb537e34c91831ef63">
+  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="5b9c3268021842009f736bfea5ab900584ffac73">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_RDK" />
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>


### PR DESCRIPTION
Details: For suspended callsing use SIGHUP to kill unresponsive WebProcess (instead of SIGFPE) to skip minidump report.

In suspended state webkit browser plugin kills web process immediately on the very first unresponsiveness that produces false crash reports.

Reason for change: Fix crash report on browser shutdown
Test Procedure: Webapps smoke testing (launch and exit)
Priority: P1
Risks: Low


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk, Merge Commit SHA: 5b9c3268021842009f736bfea5ab900584ffac73
