### PR TITLE
RDKTV-34129 - Auto PR for rdkcentral/meta-middleware-generic-support 816

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="73accc784371f2012ca3265cb0e85cd9276bd5e7">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="867d2070f295033a145167b87fdae5169daeedd7">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Details: For suspended callsing use SIGHUP to kill unresponsive WebProcess (instead of SIGFPE) to skip minidump report.

In suspended state webkit browser plugin kills web process immediately on the very first unresponsiveness that produces false crash reports.

Reason for change: Fix crash report on browser shutdown
Test Procedure: Webapps smoke testing (launch and exit)
Priority: P1
Risks: Low


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: 867d2070f295033a145167b87fdae5169daeedd7
