### PR TITLE
RDKEMW-4416 - Auto PR for rdkcentral/meta-rdk-video 834

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="9660402305c7af3c188a7e606d704fdbccba1f4c">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="87528f3023f04f006b29f9a1b418c0ff4d81a626">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Issues: Currently, Playready/Widevine .bb files are placed in each platform vendor release layer.

Reason for change:
1. As OCDEM is a generic middleware component, Playready/Widevine .bb files should be available in meta-rdk-video layer.
2. So, added the .bb files into meta-rdk-video layer

Test Procedure: Verified the build and playback.

Risks: None.

Signed-off-by: antonyxavier_francis@comcast.com


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 87528f3023f04f006b29f9a1b418c0ff4d81a626
