### PR TITLE
SERXIONE-7573 - Auto PR for rdkcentral/meta-rdk-video 974

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="a089180e9654e4cd6642bcbcaf63aa998331fd59">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="260b12a7edb0c54c3566a73359a4d6fa1dbabd92">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Tubi app crashes in CachedResourceStreamingClient::responseReceived SEGV
There is an existing fix upstream in WPEWebKit wpe-2.46 and wpe-2.38.
https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1531

Bring it in as a patch.
https://bugs.webkit.org/show_bug.cgi?id=266973


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 260b12a7edb0c54c3566a73359a4d6fa1dbabd92
