### PR TITLE
RDKEMW-5954 - Auto PR for rdkcentral/meta-rdk-video 1226

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="6022fda057f3f958f3055e36f9337b87d235beb9">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="d83f3d4f03c6a182b3538db464f9130888766445">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="999f439c9977d9d0268ea8a0003b4568504babc9">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="e4577d48fd075255ff616ceeefe311ab68efb65b">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: Added the securemount.service & requires RequiresMountsFor =/opt/secure and removed from wpeframework.service
Test Procedure: please referred ticket descriptions
Risks: Medium
Priority: P1


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: e4577d48fd075255ff616ceeefe311ab68efb65b
- Repository: rdkcentral/thunder-startup-services, Merge Commit SHA: e5082ec7c42117b5ebef3f76b77a0d0eeb6f1502
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: d83f3d4f03c6a182b3538db464f9130888766445
