### PR TITLE
RDKEMW-6540 - Auto PR for rdkcentral/meta-rdk-video 1261

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="16ca0a9561589d1bd14863ce3c28dae4acdaf991">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="3f75619956ffc422a1a70720b34e9511800cb8dc">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: Currently KillSignal and ExecStop for WPEFramework Service is defined as SIGKILL and kill -9. This must be changed to use SIGTERM to avoid improper shutting down of the thunder services.
Test Procedure: please referred ticket descriptions
Risks: Medium Priority: P1


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 3f75619956ffc422a1a70720b34e9511800cb8dc
