### PR TITLE
RDKEMW-6629 - Auto PR for rdkcentral/meta-rdk-video 1282

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="ad66434362237dea909e4889a36c38117cecfa9b">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="c1ee05218b00048f93252b41e896db7d8bd38cc0">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: Modified the thunder hang recovery with below
1. Only when the thunderHangRecovery is enabled, polling will be started for monitoring wpeframework otherwise no action will be taken
2. Create the json file to store the RFC value only when the RFC set is called when the device booted initially without any json file
3. Removed the old file and created new file to store the RFC value Test Procedure: Test and verified
Risks: Medium
Priority: P1


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: c1ee05218b00048f93252b41e896db7d8bd38cc0
