### PR TITLE
RDKEMW-6934 - Auto PR for rdkcentral/meta-middleware-generic-support 1302

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="802e93aaa661baa9403fad9b01108d3d9dea8fb5">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="0f7973400ae43a5bb0c3ed0dfb78192568075894">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="564e7be7d06667ef0beb4230350a15c88ea7efea">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="8690ed0a6a15a467b2db26ca5e4c3945762ee9fe">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change:
WPEFramework crashwith signature WPEFramework::Plugin::USBDeviceImplementation::libUSBEventsHandlingThread with fingerprint 14820164 during Reboot testing. [RDKMW][RTK-XIONE] WPEFramework crash Observed while Launching and Playing XUMO Play.

Test Procedure:
Reboot testing needs to do. No. of Reboots: Atleast 50 Reboots. Refer RDKEMW-6934, RDKEMW-6935, RDKEMW-6785
Risks: High
Priority: P1


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 8690ed0a6a15a467b2db26ca5e4c3945762ee9fe
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: 0f7973400ae43a5bb0c3ed0dfb78192568075894
