### PR TITLE
RDKEMW-6681 - Auto PR for rdkcentral/meta-rdk-video 1303

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="8e1d8438750db87973fc182c53485fcf589c4ba3">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="7713c3410dcbb145c7655c9cf2edd3b20ac8cf4b">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: getDolbyVisionMode api fails to return "Dark/Bright" in response for AVOutput plugins.

Reason for change: Added condition in getDolbyVisionMode() to return error for non DV content.
Test Procedure: as per JIRA
Risks: None
Priority: P2


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 7713c3410dcbb145c7655c9cf2edd3b20ac8cf4b
