### PR TITLE
RDKEMW-6261 - Auto PR for rdkcentral/meta-rdk-video 1433

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="bbb1f3292afb4c87ab08a1b5e0a339698e80b878">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="a7426af14ec9a075dd32ca2191a405b373253005">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: Backport PR-1923 as a patch from R4.4.4 into R4.4.3.

PR-1923 Summary
* [Backport] Offloading of Dangling proxies notification
When Communication thread receives a broken pipe,
dangling notification is sent to the CommunicationServer.
This will make the comm thread wait on the notifier lock when
activation/deactivation of any plugin is in progress and
the notifier lock for IPlugin::INotification was already taken
The notification to ICOMLink::INotification subscribers is now
offloaded to a Job in CommunicationServer.

* Fix the missing Release in Dangling Notification
 
Test Procedure: reboot the device and observe the shutdown time
Risks: Low
Priority: P0
Signed-off-by:Boopathi Vanavarayan <boopathi_vanavarayan@comcast.com>


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: a7426af14ec9a075dd32ca2191a405b373253005
