### PR TITLE
RDKEMW-7064 - Auto PR for rdkcentral/meta-rdk-video 1395

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="1e83a582c5a76994dd0e84b4eed02637fe2d2524">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="58c00a531313a71bd79939b8047affeb7fbd3c2f">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason For Change:
Some platforms do not allow secure buffer allocations after Essos RM Revoke has been called, however, the pipeline may not have been shutdown yet and is still trying to decrypt data. We need to skip decryption in this case.

Priority: P2

Risks: Low

Test Procedure:
- Verify encrypted playback
- Verify Source switch during encrypted playback
- Verify app switch during encrypted playback

Change-Id: I59f16bd77bd0c476ac53d78998327188a7495568

DoD checklist: https://ccp.sys.comcast.net/browse/RDKEMW-7064?focusedId=22978717&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-22978717


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 58c00a531313a71bd79939b8047affeb7fbd3c2f
