### PR TITLE
RDKEMW-6225 - Auto PR for rdkcentral/meta-rdk-video 1496

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="58c00a531313a71bd79939b8047affeb7fbd3c2f">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="a62a55f72e2499d9873cb85a2c6eff9262c01c82">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: Upgrade to new release - 0.25.0 with following Bug fixes

- Implemented SetHostname method which can send device's hostname over DHCP explicitly
- Implemented L1/L2 for netsrvmgr (RDK), libnm backends
- Clamped the WIFI Noise value to be within 0 dBm to -96 dBm
- Handled Plugin Termination sequence to stop the monitoring thread before exit
- Handled out-of-process plugin configuration as string
- Fixed Router Discovery to handle dual interface
- Fixed Internet Connectivity Monitoring to not to poll unless requested
- Addressed coverity reported issue


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: a62a55f72e2499d9873cb85a2c6eff9262c01c82
