### PR TITLE
RDKEMW-8985 - Auto PR for rdkcentral/meta-rdk-video 1797

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="9bbaedc3d03c56f030f77c14e2fdea90c1a35fff">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="44117e283d8e27bb65cc649c5a783cd63fdea53d">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason for Change:Validated the Thunder R4.4.3 + RDK patch using the BigJSONTest Test Plugin. The TestConsumer receives only the first three events. The fourth event is not notified to the consumer—it gets stuck at the Thunder layer. The fifth event is received by the Thunder layer but gets mixed up with the pending fourth message, causing deserialization errors due to the combined data from both messages. After this point, no further events are received or notified, and the Thunder layer enters a bad state. I suspected the Metro changes introduced in PR #1625. After reverting those changes and revalidating, the issue was resolved
Test Procedure:Please refer to the ticket description. 
Risks: Medium
Priority: P1


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 44117e283d8e27bb65cc649c5a783cd63fdea53d
