### PR TITLE
RDKEMW-8889 - Auto PR for rdkcentral/meta-rdk-video 1811

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="d79a930ffd591e08a86ccdd43f80626cfe4b6d2b">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="1d86d834dbfd5ed31399566f9d3a537ef37f4f24">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: Since RDK is using Systemd Based activation of Plugins, we do not need Thunder to populate metadata on startup.
Test Procedure: Successful activation of Plugins on Reboot test; Also test FSR to ensure the OCDM is properly activated in both Pre & Post
Risks: Low


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 1d86d834dbfd5ed31399566f9d3a537ef37f4f24
