### PR TITLE
RDK-55604: Add meta-clang layer

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -15,4 +15,8 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 
+  <project groups="rdk" name="meta-clang" path="rdke/common/meta-clang" remote="rdkcentral" revision="kirkstone">
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_CLANG" />
+  </project>
+
 </manifest>


### PR DESCRIPTION
This layer provides `clang-native` and `libclang` which is required by secclient for all platforms and any code dependent on bindgen for generating Rust bindings at build-time.