### PR TITLE
RDKEMW-9285 - Auto PR for rdkcentral/meta-rdk-video 1840

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="f6f5a83276b3b26d857a52f416443c515ae4c113">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="7094f9291e1fe76b8cef5aa40bfb408dc947a87b">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: RDKEMW-9285 : "Activation of blocked by Systemd" is printed for each plugin
Reason for change : Removed the activation logs and drop-in services for Thunder Performance at bootup
Test Procedure : please referred ticket descriptions
Risks : Medium
Priority : P1


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 7094f9291e1fe76b8cef5aa40bfb408dc947a87b
