### PR TITLE
RDKEMW-8528 - Auto PR for rdkcentral/meta-rdk 304

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -6,7 +6,7 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
-  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="6872de1e0f9da9ffd66c02fd50209bc05dd0f39e">
+  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="3696e6a0ecb485aaa26cdf8fec119317126cfa2b">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_RDK" />
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>


### PR DESCRIPTION
Details: Reason for change:  Remove logMilestone.sh installation from rdk-logger
Test Procedure: Build for XIONE with wpe-2.46 enabled
Risks: Low
Signed-off-by: 



List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk, Merge Commit SHA: 3696e6a0ecb485aaa26cdf8fec119317126cfa2b
