### PR TITLE
RDKEMW-9572 - Auto PR for rdkcentral/meta-middleware-generic-support 1991

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="b4da66710d42e4aa98f133212ddbe5d569f248be">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="5105a7588d2d7f7814a76c5e7d700aef2c8b1b32">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="2c8efed816f38fecfc883dd8bbafa21627993dcc">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="ba4a9630131e7fa577679479f06966aca8c7f244">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: RDKEMW-9572: Update entservices-casting PV to v1.2.12
Reason for Change: Fix for Miracast Service crash while reactivating the service


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: 5105a7588d2d7f7814a76c5e7d700aef2c8b1b32
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: ba4a9630131e7fa577679479f06966aca8c7f244
