### PR TITLE
RDKEMW-9638,RDKECOREMW-1058,RDKECOREMW-1011,RDKECOREMW-1057 : Cherrypick RDKEMW-9293 as hotfix

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="refs/tags/1.11.0">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="72406b379c33dd91c50bfcca901b8cf28a7e2223">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Reason for Change: to fix the wpeframework crash when deactivating the plugins through systemd trigger