### PR TITLE
RDKEMW-8491 - Auto PR for rdkcentral/meta-rdk-video 1699

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="77aa4f68122a346b9b4baf871652dd1bb28b58ef">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="ce97771ee6b92ea4414a8125c3eab8a330778da1">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: RDKEMW-8491: Remove ctrlm-hal-irdb from MW
IRDB plugin is built in the vendor layers now, so the middleware doesn't need the IRDB HAL headers installed.


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: ce97771ee6b92ea4414a8125c3eab8a330778da1
- Repository: rdkcentral/rdke-tv-config, Merge Commit SHA: 29c33566b0a7e4f8418148ea6a6dd24de46fa4fc
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: ce97771ee6b92ea4414a8125c3eab8a330778da1
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: ce97771ee6b92ea4414a8125c3eab8a330778da1
- Repository: rdkcentral/rdke-tv-config, Merge Commit SHA: 29c33566b0a7e4f8418148ea6a6dd24de46fa4fc
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: ce97771ee6b92ea4414a8125c3eab8a330778da1
