### PR TITLE
RDKEMW-9859 - Auto PR for rdkcentral/meta-rdk 324

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -6,7 +6,7 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
-  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="4aeaf6fffc3583121f5ec25ccfd83077eb890e4a">
+  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="913d590ee4b8df629fa49da29aa7423056909028">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_RDK" />
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>


### PR DESCRIPTION
Details: RDKEMW-9859 : Cleanup of xre-receiver code
Reason for change: CPESP-3386 Remove UI Components / Recipes from OEM Yocto Layer
Test Procedure: Boot the TV and check the rootfs for xre-receiver
Risks: low


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk, Merge Commit SHA: 913d590ee4b8df629fa49da29aa7423056909028
