### PR TITLE
RDKEMW-10174 - Auto PR for rdkcentral/meta-rdk 286

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -6,7 +6,7 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
-  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="7d8918ebea2ad7bdd5ddef73ffaa28c1d19ba108">
+  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="7829f9f9dc81e248a49f2c2f1b5b49336df570fc">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_RDK" />
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>


### PR DESCRIPTION
Details: RDKEMW-10174 : App Not Killed by Dobby OOM at Max Memory Limit
Reason for change: enable swap limit in OCI config template


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk, Merge Commit SHA: 7829f9f9dc81e248a49f2c2f1b5b49336df570fc
