### PR TITLE
RDKEMW-10267 - Auto PR for rdkcentral/meta-rdk-video 2018

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="8fa3f2241f85f4b64ce031989ae8cef462e702b8">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="c397d5689816ed3e2f30d1575a72c60fbe865d49">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: commit
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/871c426b1e25b5f8d87873b20c16acf29acbca97 results in a crash when we create OffScreenCanvas and get the "WebGL" context. This patch
reverts the offending commit - patch from upstream wpe webkit - https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1467 Test Procedure: Launch SkyStoreDE app without widget workaround and no crash should be seen. Other test guidance has been mentioned in the ticket.
Risks: Low
Priority: P0


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: c397d5689816ed3e2f30d1575a72c60fbe865d49
