### PR TITLE
RDKEMW-10264 - Auto PR for rdkcentral/meta-rdk-video 2004

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="9c47fd7a2843b0c586634f04e69197441753c5b2">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="c09497483698b435783b9e1a784f3f551e85d4ad">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: commit
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/871c426b1e25b5f8d87873b20c16acf29acbca97 results in a crash when we create OffScreenCanvas and get the "WebGL" context. This patch
reverts the offending commit - patch from upstream wpe webkit - https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1467 Test Procedure: Launch SkyStoreDE app without widget workaround and no crash should be seen. Other test guidance has been mentioned in the ticket.
Risks: Low
Priority: P0


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: c09497483698b435783b9e1a784f3f551e85d4ad
