### PR TITLE
RDKEMW-10064 - Auto PR for rdkcentral/meta-middleware-generic-support 2086

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="9cf840cc3743824fa91f9cd58e1e48c7754a47cb">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="b9c13da5927b9152d4dafb814a4405e056ba7049">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Details: Reason for Change: Reintroduced the condition check before calling clear() in clearDrmSession. This was lost during DRM refactoring and was causing increase in PLTV XSTPP-999 failures.

Changes:
- Added getFailedKeyIdStatus() method to DrmSessionManager
- Modified clearDrmSession() in AampDRMLicenseManager to add condition checks
- Only clear license downloader when conditions are met


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: b9c13da5927b9152d4dafb814a4405e056ba7049
