### PR TITLE
RDKEMW-10182 - Auto PR for rdkcentral/meta-middleware-generic-support 2119

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="e9bc186742e7bfc9f5d296da405e48a478576606">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="a0944fb87be21b168109bf98e1c77383897857b0">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Details: RDKEMW-10182 : Remote firmware download is not happening

Reason for change: rdkfwupdater not sending remote formware info as part
of xconf query.
Test Procedure: rdkfwupdater should send remote firmware info to xconf
server
Risks: High
Priority: P0


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: a0944fb87be21b168109bf98e1c77383897857b0
