### PR TITLE
RDKEMW-10398 - Auto PR for rdkcentral/meta-rdk-video 2034

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="41b07c2da67b84651240e29c794530403ef033c2">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="a3bb3b97a4d0e64a74cd672c032b5550677c34df">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: RDKEMW-10398: [BCM] Vendor release layer cleanup on ocdm patches
Updating the latest SHA value for playready and widevine for adding the DRM support for Broadcom VA.


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: a3bb3b97a4d0e64a74cd672c032b5550677c34df
