### PR TITLE
RDKEMW-10309 - Auto PR for rdkcentral/meta-rdk-video 2016

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="810cbcb20180ebf20bfe38f069cef1ca9790f1e9">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="12e71acc7d5e080fff0baae7d11a1684a17b48c5">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: RDKEMW-10264 : commit
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/871c426b1e25b5f8d87873b20c16acf29acbca97 results in a crash when we create OffScreenCanvas and get the "WebGL" context. This patch
reverts the offending commit - patch from upstream wpe webkit - https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1467 Test Procedure: Launch SkyStoreDE app without widget workaround and no crash should be seen. Other test guidance has been mentioned in the ticket.
Risks: Low
Priority: P0


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 12e71acc7d5e080fff0baae7d11a1684a17b48c5
