### PR TITLE
RDKEMW-9745 - Auto PR for rdkcentral/meta-middleware-generic-support 2185

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="e8577f4c52ea51f1b12f3d0cf70c10a6611f5721">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="63c2944ce2c50b876d7771dc8797cb0179b6a0e3">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Details: RDKEMW-9745 : btMgrBus crash with function BtrCore_BTGetPairedDeviceinfo 
Reason for change: Add defensive NULL check for interface handle in DBus message creation
Priority: P1

Test Procedure: Follow the steps provided in description. 
Risks:Low


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: 63c2944ce2c50b876d7771dc8797cb0179b6a0e3
