### PR TITLE
RDKEMW-10148 - Auto PR for rdkcentral/meta-middleware-generic-support 2148

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="5a2898e929b36782d5cd47f651dd302b57e36079">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="c7b9ac485f4addd25679e6fcd46e50475799054e">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change:
To prevent the current service from shutting down during DEEPSLEEP when btmgr.service stops, by switching the dependency to bluetooth.service which remains active.

Risks: Medium
Priority: P1

Signed-off-by: Natraj Muthusamy[Natraj_Muthusamy@comcast.com]


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: c7b9ac485f4addd25679e6fcd46e50475799054e
