### PR TITLE
RDK-59966 - Auto PR for rdkcentral/meta-rdk 331

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -6,7 +6,7 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
-  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="20a17cda5f9bf945e07611da0dbd1ce0dc0e50b3">
+  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="3af71f87c1e5ad1f0c0dafad6529f84309651542">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_RDK" />
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>


### PR DESCRIPTION
Details: RDK-59966 : Bring the required changes to build RDKB stack
Reason for change:
1. Update rdkb.inc with all broadband related variables
2. Update rdk.conf to remove unused setting which is causing failure in broadband
3. Update the components to build RDKB without disturbing client profiles
4. Update setup-environment to support poky
5. Update bblayers.conf.sample to support poky and RDKB layers
6. Update webconfig-framework to include the changes required for RDKB.
7. Update cimplog for RDKB requirement Note: rdkb.inc should be reviewed and cleaned up properly after all the required layers are migrated.
8. Bring in required recipes for RDKB to build which are not OE components.

Changes are mostly for broadband without affecting the current client profiles. 


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk, Merge Commit SHA: 3af71f87c1e5ad1f0c0dafad6529f84309651542
