### PR TITLE
RDKEMW-9619 - Auto PR for rdkcentral/meta-rdk-video 2177

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="119de07eee807b0d22d15d55e992aeb5fbfa1a9f">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="ff420bcae754da58815a3f74430240ba558a8b85">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="af38ea84fa5b9f634dbb2ddbde818fef8119fbe1">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="8be58f3a85583b6f3fbeb0626bf67b4c166034c1">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: RDKEMW-9619 : NTP Marker name update

Reason for change:
1) Update the NTP Telemetry Marker name
2) Remove NTP Client restarts
Test Procedure: Validate the Markers. Results are captured in the ticket
Risks: Low
Priority: P1
Signed-off-by: Sindhuja [Sindhuja_Muthukrishnan@comcast.com](mailto:Sindhuja_Muthukrishnan@comcast.com)


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 8be58f3a85583b6f3fbeb0626bf67b4c166034c1
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: ff420bcae754da58815a3f74430240ba558a8b85
