### PR TITLE
RDKEMW-9552 - Auto PR for rdkcentral/meta-middleware-generic-support 2239

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="ff420bcae754da58815a3f74430240ba558a8b85">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="29c8a9685874959e92e847080aec6cca1ee85290">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="8be58f3a85583b6f3fbeb0626bf67b4c166034c1">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="eb71d09880f703e037d55f40d64970228b5270ae">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: RDKEMW-9552 : Improve L1 tests for HdmiCecSource

Reason for Change: update tags to
entservices-inputoutput: 1.6.6


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: eb71d09880f703e037d55f40d64970228b5270ae
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: 29c8a9685874959e92e847080aec6cca1ee85290
