### PR TITLE
RDKEMW-10960 - Auto PR for rdkcentral/aamp 737

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="eb71d09880f703e037d55f40d64970228b5270ae">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="806e7a8f77fe2605ff6c39f0cbb7f809062bb187">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: RDKEMW-10960 : RaspberryPi MW build failure is blocking CI build verification
Reason for change: Enabled the RDK_SVP cFlag based on the distro feature configuration
Test Procedure: Need to ensure the playback behavior
Priority: P1

Signed-off-by: Varatharajan_Narayanan <Varatharajan_Narayanan@comcast.com>


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 806e7a8f77fe2605ff6c39f0cbb7f809062bb187
