### PR TITLE
RDKEMW-9242 - Auto PR for rdkcentral/meta-rdk-video 2170

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="d1ce4c595bce7765707eaaacef83afbcee1adc20">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="7895a3bf2ed61493d54261a7b0c09a50c4bf8e44">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: RDKEMW-11094: Network Migration changes for ENTOS
Reason for change: Remove tr69hostif dependency and read boot info directly from file instead. 
Test Procedure: Build RDKE image
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 7895a3bf2ed61493d54261a7b0c09a50c4bf8e44
