### PR TITLE
RDKEMW-11155 - Auto PR for rdkcentral/meta-rdk-video 2172

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="7895a3bf2ed61493d54261a7b0c09a50c4bf8e44">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="a003dcf187931981ef34d347e4639e4735127dd3">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: RDKEMW-11155: NetworkManager connectivity check endpoint configuration

Reason for change: Enable networkmanager connectivity check for RDK based devices. Adding default gnome networkmanager connectivity check endpoint url


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: a003dcf187931981ef34d347e4639e4735127dd3
