### PR TITLE
RDKEMW-7496 - Auto PR for rdkcentral/meta-middleware-generic-support 2213

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="5c907dc019ca0aaf95e5346547e6379e9f30e2ff">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="56f13ef1d67df52296cec5bfa7604ec0b67e2f46">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Details: RDKEMW-7496: Dolby Atmos not available in Netflix.

Reason for change: Ensuring Dolby Atmos is available in Netflix
Test Procedure:
Risks: low
Priority: P1

Signed-off-by:Hayden Gfeller <Hayden_Gfeller@comcast.com>


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: 56f13ef1d67df52296cec5bfa7604ec0b67e2f46
