### PR TITLE
RDKEMW-11453 - Auto PR for rdkcentral/meta-rdk-video 2315

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="754c613096876ad6f1cd6f2bf9096b977fbc6221">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="dc89c7b0f43c81174158d5d3d9f9ec27a5a7d6df">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: RDKEMW-11453 : Update NetworkManager to support Thunder R5.x

Reason for change: Upgrade to new release - 1.10.0 with following Bug fixes
- Cleanup the component to be compatible with Thunder-R5.3
Test Procedure: Verify Thunder-R5.3 build
Risks: Low
Signed-off-by: Thamim razith Abbas Ali <tabbas651@cable.comcast.com>


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: dc89c7b0f43c81174158d5d3d9f9ec27a5a7d6df
