### PR TITLE
RDKEMW-12226 : [RDKE] [Generic] Fix the double free issue in widevine…

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="6b91fb5c97638d2a94a154ee671ff5b35d8051ef">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="cd622efbd0f14473d32b7628f702777413272095">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Reason for change: To avoid double free in Widevine Decrypt() failure case.
Test Procedure: Verify the build and WV playback.
Risks: None.

Signed-off-by: thenmozhi_kathiravan@comcast.com