### PR TITLE
RDKEMW-6162 - Auto PR for rdkcentral/meta-rdk-video 2114

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="6b91fb5c97638d2a94a154ee671ff5b35d8051ef">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="fbd37afb926cf53bbe54cf3b0f73a5433e7ab136">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: Migrate AAMP DS Manager client event to use libds client calls for RDK-E only(libds updates not available in RDK-V)
Test Procedure: Ensure that HDCP status, HDMI hotplug events, and resolution change notifications are functioning correctly.
Priority: P1
Risks: Low

Signed-off-by: Varatharajan_Narayanan <Varatharajan_Narayanan@comcast.com>


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: fbd37afb926cf53bbe54cf3b0f73a5433e7ab136
