### PR TITLE
RDKEMW-12247 - Auto PR for rdkcentral/meta-rdk-video 2401

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="66a621a2ac90f28a6b0e7c32197d58b4d2ca4b49">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="b3e8a9250b13634e94084f6a653ea1edef735a12">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: Since RDK is using Systemd Based activation of Plugins, we do not need Thunder to populate metadata on startup.
Test Procedure: Successful activation of Plugins on Reboot test; Also test FSR to ensure the OCDM is properly activated in both Pre & Post
Risks: Low


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: b3e8a9250b13634e94084f6a653ea1edef735a12
