### PR TITLE
RDKEMW-11659 - Auto PR for rdkcentral/meta-rdk-video 2482

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="f7f34653b0ffe0dbbb8b92518c40ec26577500c3">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="58b0e04d490d2bb85ceccaa2ece872f8860685c9">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: Increase max limits for each key from 3K to 10K to allow storing tokens for different use cases. Increase limits for namespace from 10K to 50K.
Test Procedure: None
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>

* Copy workerpool setup from Thunder tests (Thunder/Tests/unit/workerpool/) Make tests less state agnostic

* RDKEMW-7050 : fix coverity issues

Reason for change: initialize sqlite handle with nullptr to mute coverity report.
Test Procedure: None
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>

* adapt to the changes in googletest framework (Invoke() deprecated)

* adapt to the changes in Thunder framework (IShell interface)

* adapt to the changes in Thunder framework (Root requires locator)

Revert "RDKEMW-3385: Implement Caching in New PackageManager (#265)" This reverts commit a6e04a4.

!!! revert unwanted change from unidientified developer who is not maintaining the code !!!

version: Patch


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 58b0e04d490d2bb85ceccaa2ece872f8860685c9
