### PR TITLE
RDK-60535 - Auto PR for rdkcentral/meta-rdk-video 1355

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="dbf32382fdfee2dafbc7084c91c1c8dba7d629a8">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="c697954e91e09b8ffa25421600a38dbe5c23c714">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: RDK-60535: WPEWebKit 2.46 upgrade

Reason for change: Bring the recent wpe-webkit 2.46 recipe.
Disabled by default
Test Procedure: See Jira ticket
Priority: P1
Risks: Low (disabled by default)


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: c697954e91e09b8ffa25421600a38dbe5c23c714
