### PR TITLE
RDKEMW-12842 - Auto PR for rdkcentral/meta-rdk 483

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -6,7 +6,7 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
-  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="99a8a7713176144f4e90ffc0f01a5064b3f61ddc">
+  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="1d5ed1d9cb4cdda14ae82cb63cf1a36cc271d0f0">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_RDK" />
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>


### PR DESCRIPTION
Details: Reason for change:
The clang compiler is required for the secclient-rs module. This commit integrates the meta-clang recipe, which provides compiler version 1.72.0.


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk, Merge Commit SHA: 1d5ed1d9cb4cdda14ae82cb63cf1a36cc271d0f0
- Repository: rdkcentral/rdke-middleware-generic-manifest, Merge Commit SHA: f3e2eaca277764ee7402733ff11047c08adf563e
