### PR TITLE
RDKEMW-12118: Modifications needed in iarmmgr to remove vendor env var

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -6,12 +6,12 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
-  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="3419271ac4f8eef66274981c2c49db0434120c6b">
+  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="1cab18f8a0717431435478c3f161cb4b1a34f6c3">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_RDK" />
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="da24b738ee23247a844351af8aa5018282f3bf98">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="5f1f2eae507177349e674847b992cf3234b67185">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Reason for change: Remove dsmgr service patches to move these environments to vendor layer.
Test Procedure: see Jira ticket
Risks: None
Priority: P1