### PR TITLE
RDKEMW-12842: Include meta-clang needed for secclient-rs

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -15,7 +15,7 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 
-  <project groups="rdk" name="meta-clang" path="rdke/common/meta-clang" remote="rdkcentral" revision="kirkstone">
+  <project groups="rdk" name="meta-clang" path="rdke/common/meta-clang" remote="rdkcentral" revision="refs/tags/rdk-4.1.0">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_CLANG" />
   </project>
 


### PR DESCRIPTION
Reason for change:
The clang compiler is required for the secclient-rs module. This commit integrates the meta-clang recipe, which provides compiler version 1.72.0.