### PR TITLE
RDKEMW-12975 - Auto PR for rdkcentral/meta-rdk-video 2615

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="541e7e4620d2de5ef4c6b36236b079dd7a63115d">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="4527a5abe9e4d12c9b71d661480e8bddd7e68c54">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: dnsmasq-dobby.conf is already installed to /etc/NetworkManager/ path.
Remove it from /etc/ since sysint installs all conf files to /etc by default.
Test Procedure: Build RDKE image
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 4527a5abe9e4d12c9b71d661480e8bddd7e68c54
