### PR TITLE
RDK-59964 - Auto PR for rdkcentral/meta-rdk-video 2639

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="958a6f5f5939c3d29de02bbc3236daf2f64907c5">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="776a4c1c4d7dd7d550d99b12aeaccd729b258098">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: Start avahi-autoipd once the interface is up and delete the same when there is valid global IP.
Test Procedure: check whether link local IPv4 is assigned to wlan0 and eth0 when there is no valid IP.
Priority:P1
Risks: Medium
Signed-off-by: Gururaaja ESR<Gururaja_ErodeSriranganRamlingham@comcast.com>


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 776a4c1c4d7dd7d550d99b12aeaccd729b258098
- Repository: rdkcentral/networkmanager, Merge Commit SHA: cd0b5c0fe55bd75df551b4b0183094e91de8f6da
- Repository: rdkcentral/sysint, Merge Commit SHA: 73181a5584492fd205116077b6aba3ef9b0951aa
