### PR TITLE
RDKOSS-578: move meta-clang to middleware manifest

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -6,7 +6,6 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
-
   <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="595555b15de4dffe16d735db075c389248c35d00">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_RDK" />
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />


### PR DESCRIPTION
Reason for the change: Move meta-clang to the Middleware manifest since it is maintained by OSS.