### PR TITLE
RDK-60607 - Auto PR for rdkcentral/meta-rdk 513

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -6,7 +6,7 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
-  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="99f7d62a5a494b8154b5d8b6e35fca7947e20b58">
+  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="595555b15de4dffe16d735db075c389248c35d00">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_RDK" />
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>


### PR DESCRIPTION
Details: Reason for change:  Upgrade RBUS to 2.11.0 which has Coverity Fixes for rtMessage/rbus
Test Procedure: Tested and verified
Priority: P1
Risks: Medium


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk, Merge Commit SHA: 595555b15de4dffe16d735db075c389248c35d00
