### PR TITLE
RDKEMW-12842 - Auto PR for rdkcentral/rdke-middleware-generic-manifest 1111

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -6,7 +6,7 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
-  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="595555b15de4dffe16d735db075c389248c35d00">
+  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="bcc0daeba7069e3dee27c2f599719a50401e8f50">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_RDK" />
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>


### PR DESCRIPTION
Details: Reason for change:
The clang compiler is required for the secclient-rs module. This commit integrates the meta-clang recipe, which provides compiler version 1.72.0.


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk, Merge Commit SHA: bcc0daeba7069e3dee27c2f599719a50401e8f50
