### PR TITLE
RDK-60535 - Auto PR for rdkcentral/meta-rdk-video 2726

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="625ee19a0afd69f1ce7ded7cc66c07f53dd2c910">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="9118e09e3d165b7e7f2f489f092bda6e3a3767bc">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: RDK-60535, RDKEMW-12822 : WPEWebKit 2.46 rev upgrade

1) [MSE] Only extend first sample when it's a sync sample
2) Improve ftrace tracing support and integrate with skia, angle and libwebrtc
3) Clang20 compilation fixes
4) Allow selecting the source of the memory measurements
5) Add API for OpportunisticSweepingAndGarbageCollectionEnabled

Reason for change: WPEWebKit 2.46 revision upgrade
Test Procedure: Web apps smoke testing
Priority: P1
Risks: Low (disabled by default)


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 9118e09e3d165b7e7f2f489f092bda6e3a3767bc
