### PR TITLE
RDKEMW-13837 - Auto PR for rdkcentral/meta-middleware-generic-support 2643

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="bfefed72ab8c1c04d943f089fa9f8f87016fec6e">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="174ba589903f7002f23fd03dbb095d90cd284c8b">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Details: RDKEMW-13837: Update RDKE Dobby recipe with v3.16.1 release
Reason for change: Upgrade the Dobby version to 3.16.1
Test Procedure: Refer ticket
Risks: Low


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: 174ba589903f7002f23fd03dbb095d90cd284c8b
