### PR TITLE
RDKEMW-9777 - Auto PR for rdkcentral/meta-rdk-video 2841

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="942e5fb586e012ead047bb9fa064ca15fe8e4eb8">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="3466984e12c836e5bca9095e471bd3ccef32b1ba">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: This fixes the handling of invalid streams with multiple DTS = 0 samples. Modifying PTS values for all of them results in unexpected behavior, playback issues, PTS reordering, etc.

The problem was spotted in a video web application that uses TS -> MSE transmuxing, when starting video playback on some streams there was microblocks.


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 3466984e12c836e5bca9095e471bd3ccef32b1ba
