### PR TITLE
RDKEMW-13912 - Auto PR for rdkcentral/meta-rdk-video 2816

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="003ed7ba68edd3a152fc1b7d349381897336a636">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="fa7a9f3cb353b4ce417b654b98d967c8e22c7ad2">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: Reason for change: When starting the browser with voice guidance disabled, enabling it afterward via quick access menu (without effectively leaving the browser) does not enable accessibility cache in browser without a page reload, which causes voice guidance to not be heard. 

Test Procedure: See ticket
Priority: P1
Risks: Low


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: fa7a9f3cb353b4ce417b654b98d967c8e22c7ad2
