### PR TITLE
RDKEMW-14030 - Auto PR for rdkcentral/meta-rdk-video 2861

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="79c925f879f032d7f81aa2a73c27f38e468eae2e">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="6634fb1526b2774f144de802a59646a582862445">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: 
Issue:
Google API keys are explored in public repo (widevine-rdk)

Reason for change:
1. Removed the hardcoded widevine provisioning server url/Keys from widevine-rdk github.

Test Procedure: build verified

Risks: None.

Signed-off-by: antonyxavier_francis@comcast.com


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 6634fb1526b2774f144de802a59646a582862445
