### PR TITLE
RDKEMW-13189 - Auto PR for rdkcentral/meta-middleware-generic-support 2692

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="a45bca9861bd045dafe3dc008c2b627212a60a43">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="8ff541b6018f578c25d109dac9d879cb35012458">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Details: …eboot

Reason for change: Made device address buffer is always null‑terminated after copying
Test Procedure: Check ticket description

Risks: Medium
Priority: P1


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: 8ff541b6018f578c25d109dac9d879cb35012458
