### PR TITLE
RDKEMW-14690 - Auto PR for rdkcentral/meta-middleware-generic-support 2693

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="088a9248461d77b0f9035885593bb85817b20613">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="782faa0de84a82d74b482b1b5b494c21aef29cc1">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Details: …eboot

Reason for change: Made device address buffer is always null‑terminated after copying
Test Procedure: Check ticket description

Risks: Medium
Priority: P1


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: 782faa0de84a82d74b482b1b5b494c21aef29cc1
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: 8ff541b6018f578c25d109dac9d879cb35012458
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: 782faa0de84a82d74b482b1b5b494c21aef29cc1
