### PR TITLE
RDKEMW-14600 - Auto PR for rdkcentral/meta-rdk-video 2975

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="f3b53aac6136fbb9b7e5f44e298090bc0cadc5bd">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="90aef0d9981314dbc2e1d58547eaa78a59e3a347">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: Added validation for subsample mapping size against mapped buffer size in the GStreamer decrypt path. In case of a mismatch, append an additional subsample entry to safely account for the remaining clear bytes.
Test Procedure: Play TVOD "Violent Night" and observe log for decrypt errors
Priority: P1
Risks: None

Signed-off-by: Varatharajan_Narayanan<Varatharajan_Narayanan@comcast.com>


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 90aef0d9981314dbc2e1d58547eaa78a59e3a347
