### PR TITLE
RDKEMW-14361 - Auto PR for rdkcentral/meta-rdk-video 3004

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="0e7d1cf1f5bc4e2d2229c3a8b4de0562eb61f785">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="acb1bcf8373baa46d5098a5f89996fc72591c693">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: 1) Expose WEBKIT_GST_VIDEO_DECODING_LIMIT env var on top of VIDEO_DECODING_LIMIT def
2) Set default limit to 4K 60fps
3) Drop 1384 patch that is already part of codebase

Reason for change: Runtime env to limit video decoding capabilities
Test Procedure: See Jira ticket
Priority: P1
Risks: Low


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: acb1bcf8373baa46d5098a5f89996fc72591c693
