### PR TITLE
RDKEMW-14673 - Auto PR for rdkcentral/meta-middleware-generic-support 2711

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="b1616fce06a7c7aa75d440670285b7afccf8b93b">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="704098c2fa90ef083b892634d9d6702b2fcbbe47">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Details: …ontrols

Reason for change: No longer need to disconnect the remote when we go into deep sleep
Test Procedure: Remote control should still reconnect after deep sleep
Risks: High
Priority: P0
Signed-off-by: Jack O'Gorman <jack.ogorman@sky.uk>


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: 704098c2fa90ef083b892634d9d6702b2fcbbe47
