### PR TITLE
RDKEMW-13372 - Auto PR for rdkcentral/meta-rdk-video 2903

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="9e6d847bb156e9e3d4a7e21cb453cdd37a5fe067">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="22f9f6c968c37802a4286edc8622db5916d14285">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: Reason for change: Some encoders add additional clear data after the subsample map.
Test Procedure: Play TVOD "Violent Night" and observe log for decrypt errors
Risks: Low


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 22f9f6c968c37802a4286edc8622db5916d14285
