### PR TITLE
RDKEMW-15096 - Auto PR for rdkcentral/meta-rdk-video 3100

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="08662f85b92e1854e10ea0500f06e21a6f5f1ced">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="cb4c536e7b33366433c55dce83ffdfe29a1ea77a">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: RDKEMW-15096 : Missing slash in URL causes query argument to be ignored

Reason for change: If the URL passed in the configuration did not end with a '/', the remaining query arguments were truncated by websocketpp and not passed to the endpoint.

Test Procedure: Build the image
Risks: low
Priority: P2

Change-Id: I8694fa3ac0a941ded2905c01bd13f68ad8a700b2


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: cb4c536e7b33366433c55dce83ffdfe29a1ea77a
