### PR TITLE
RDKEMW-15183 - Auto PR for rdkcentral/meta-middleware-generic-support 2739

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="a852f60b4994d302930baf28c9eacd7eb4b7e0e8">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="da1b4779ef419a36866619574854e7f577fd110e">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: PREVIOUS_LOG event report doesn not consider logs from beginning and only considers incremental logs from what was reproted in previous boot.
Test Procedure: please refer the ticket comments
Risks: Medium


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: da1b4779ef419a36866619574854e7f577fd110e
