### PR TITLE
RDKEMW-13606 - Auto PR for rdkcentral/meta-middleware-generic-support 2746

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="da1b4779ef419a36866619574854e7f577fd110e">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="a1047d9f943d3ea8d7720d1bdcba327dd696ef24">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Details: RDKEMW-13606:Technical fault error

Reason for change:Removed unneeded lock, which was causing deadlock between
sinkMutex and backendQueue when getStats and AttachSource were called at
similar time
Test Procedure: Refer Ticket


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: a1047d9f943d3ea8d7720d1bdcba327dd696ef24
