### PR TITLE
RDKEMW-13138 - Auto PR for rdkcentral/meta-rdk-video 3237

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="825d914cb0270bf8aeb7c17b0b3dd4cde5ad869a">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="a9677d69db8a0f518b9a538f85f0ab2903b31941">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: Reason for change: fix crash 1 caused by missing Unregister; fix crash 2 caused by duplicate Deinitialize.
Test Procedure: 1 - deactivate plugin, emit a notification
 where the recipient is in the deactivated plugin;
2 - simulate activation failure.
Risks: Low
version: Patch


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: a9677d69db8a0f518b9a538f85f0ab2903b31941
