### PR TITLE
RDKEMW-15532 - Auto PR for rdkcentral/meta-rdk-video 3289

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="a98d142e0fc805742a1c1f52aed4f30552b48ca0">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="bba26e322e5bb67d5c89053558565e28b3d47302">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: RDKEMW-15532 : Firebolt: Disable so-version in the library

Reason for change: Allow to link widget with Prime App to Firebolt libraries without version control

Test Procedure: Build the image
Risks: low
Priority: P2


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: bba26e322e5bb67d5c89053558565e28b3d47302
