### PR TITLE
RDKEMW-15643 - Auto PR for rdkcentral/meta-rdk-video 3338

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="17e0e9392ae0732668ceb7f255754c50f79c4ae4">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="51d09656d259d61765e76c8e0891aeaebbc7ee35">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: Reason for change: remove t2_init call that is setting component name for in-process Thunder plugin as ‘hdmicec’
Test Procedure: see Jira ticket
Risks: Low
Priority: P1


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 51d09656d259d61765e76c8e0891aeaebbc7ee35
