### PR TITLE
RDK-60535 - Auto PR for rdkcentral/meta-rdk-video 3286

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="0a463d7135872df20e270facfe19dbb9ecb645b0">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="72cd7ff6800499644b60579efb1b88c92cf1cc3f">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: RDK-60535: wpe-2.46 revision upgrade

1) GPU spikes with hidden animations on Amazon Luna app
2) Insert cencparser when available
3) RDKEMW-14361: Video decoding limit
4) RDKEMW-15136, RDKEMW-15137: Support AC-4 codec

Reason for change: Webkit 2.46 revision upgrade
Test Procedure: See Jira ticket
Priority: P1
Risks: Low

Signed-off-by: Andrzej Surdej <Andrzej_Surdej@comcast.com>


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 72cd7ff6800499644b60579efb1b88c92cf1cc3f
