### PR TITLE
RDKEMW-14059 - Auto PR for rdkcentral/meta-middleware-generic-support 2712

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="6fd63cb12b9d6380fed92267f714155277e90174">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="0bb3a1bb09e7da4cdf60019e914f0f3af315adaa">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Details: …ontrols

Reason for change: No longer need to disconnect the remote when we go into deep sleep
Test Procedure: Remote control should still reconnect after deep sleep
Risks: High
Priority: P0
Signed-off-by: Jack O'Gorman <jack.ogorman@sky.uk>


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: 0bb3a1bb09e7da4cdf60019e914f0f3af315adaa
