### PR TITLE
RDKEMW-16410 - Auto PR for rdkcentral/meta-rdk 718

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -6,7 +6,7 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
-  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="0e4786293a2929cf42902a48508353796014ba08">
+  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="0223e6ade3d304692dda880403cb24d044a3a37c">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_RDK" />
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>


### PR DESCRIPTION
Details: RDKEMW-16410: Reason for change: Enable the rm_work class so the build system automatically removes per-recipe work directories once they are no longer needed (typically after the recipe has successfully produced packages). This is to reduce the overall workspace size.


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk, Merge Commit SHA: 0223e6ade3d304692dda880403cb24d044a3a37c
