### PR TITLE
RDKEMW-13574 - Auto PR for rdkcentral/meta-middleware-generic-support 2641

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="b8f710498f43be1d9b90d79487d22587b987ea3e">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="ad048af4597de76162a0b71e7eae80529c0186d9">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Details: RDKEMW-13574: Device goes to standby after restarting wpeframework

Reason for change: '/tmp/pwrmgr_restarted' need to created by PowerManager service while service stop. So that PowerManager plugin doesnot force to STANDBY if '/tmp/pwrmgr_restarted' is present

Signed-off-by: yuvaramachandran_gurusamy [yuvaramachandran_gurusamy@comcast.com]


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: ad048af4597de76162a0b71e7eae80529c0186d9
