### PR TITLE
RDKEMW-16478 - Auto PR for rdkcentral/meta-rdk 730

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -6,7 +6,7 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
-  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="c86a0bfdd9ad14ce44ae8c7139583e890f1e1a42">
+  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="ff3f6e28bd8dbce53e598d019bfa782ef4f870a2">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_RDK" />
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>


### PR DESCRIPTION
Details: Reason for change: Build Scripts use opkg-make-index to generate packages.gz to upload the ipks. Since it is missing, it fails to upload ipks.


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk, Merge Commit SHA: ff3f6e28bd8dbce53e598d019bfa782ef4f870a2
