### PR TITLE
RDKEMW-14995 - Auto PR for rdkcentral/meta-middleware-generic-support 2816

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="ad048af4597de76162a0b71e7eae80529c0186d9">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="32350e519b03b50e4ac7ec8ae8cad51b0451dfbb">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: dbus crash due to invalid path.
Test Procedure: Check Ticket description.
Risks: Low
Priority: P1


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: 32350e519b03b50e4ac7ec8ae8cad51b0451dfbb
