### PR TITLE
RDKEMW-13271 - Auto PR for rdkcentral/meta-rdk-video 3535

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="b92fafeec5cfc4a3e7f67f8226851755f840f260">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="eb8c5b55d9cce48a74b57e20d7639bee6943ba2e">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: Reason for change: Fix for AVInput Thunder plugins request/response logs not coming in WPEFramework log
Test Procedure : compiled and verified
Version : Minor
Risks: Low


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: eb8c5b55d9cce48a74b57e20d7639bee6943ba2e
