### PR TITLE
RDKEMW-17337 - Auto PR for rdkcentral/meta-rdk-video 3673

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="5d8097fd128adece77de4b632a45cff5d993bb8c">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="da11017aad6f3f45610efd7f72c18159dd4fb4eb">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: Reason for change:
1. Updated playready-rdk repo to tag-1.0.1 to bring the CBCS playback support

Test Procedure: Build and CBCS playback verified

Risks: None.

Signed-off-by: antonyxavier_francis@comcast.com


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: da11017aad6f3f45610efd7f72c18159dd4fb4eb
