### PR TITLE
RDKEMW-16984 - Auto PR for rdkcentral/meta-rdk-video 3645

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="da11017aad6f3f45610efd7f72c18159dd4fb4eb">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="adfb49e4cae0033ebb8927127a05155e285396e1">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: Reason for change: When Firebolt Display APIs are called logs are not get recorded in weframework.log
Test Procedure: Check the wpeframework logs
Risks: Low
Priority: P1
version: Patch
Signed-off-by:Dineshkumar P [dinesh_kumar2@comcast.com]


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: adfb49e4cae0033ebb8927127a05155e285396e1
