### PR TITLE
RDKRM-140: Update meta-rdk-video to 1.17.0-community for RDK8 release

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE"/>
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="refs/tags/1.17.0">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="support/1.17.0-community">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO"/>
   </project>
 </manifest>


### PR DESCRIPTION
RDKRM-140: Update meta-rdk-video to 1.17.0-community for RDK8 release
Reason for Change: Update Manifest for meta-rdk-video
Risks: Low
Signed-off by: bikash_paul@comcast.com