### PR TITLE
RDKEMW-17113 - Auto PR for rdkcentral/meta-rdk-video 3637

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="2feb99ce3a557fff46485e69dab4150cfc15ac73">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="c65119b11346812163939763565e4b5c4cde9459">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: Reason for change: When Firebolt Display APIs are called logs are not get recorded in weframework.log 
Test Procedure: Check the wpeframework logs
Risks: Low
Priority: P1
version: Patch
Signed-off-by:Dineshkumar P [dinesh_kumar2@comcast.com]


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: c65119b11346812163939763565e4b5c4cde9459
