### PR TITLE
RDKEMW-17800 - Auto PR for rdkcentral/meta-rdk-video 3828

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="eeb1196761cd66c46d6f74255fe4124d1a938db3">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="384e14a5f7c2d5b58a8074bcf488ca94afb6d1ce">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="4b79158d46db893ae6a85eae500a66c4fc97286d">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="c6101366250eadc1a67593be3106689c06064daf">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: Reason for change: gstreamer-cleanup is happening on every reboot when /opt/cdl_flashed_file_name is missing. Fixing the issues as well as re-locating gstreamer-cleanup.service file to recipies-multimedia instead of sysint folder
Test Procedure: Boot the TV and check for gstreamer-cleanup metrics in rdk_milestones.log
Risks: low


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: c6101366250eadc1a67593be3106689c06064daf
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: 384e14a5f7c2d5b58a8074bcf488ca94afb6d1ce
