### PR TITLE
RDKEMW-15446 - Auto PR for rdkcentral/meta-rdk-video 4125

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="67ccbef09447288f48beed2774c1be89f8e7e913">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="490c76bd50de0759ac23dc89cc5d1e87289166e0">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: 
Switch the recipe from a floating SRCREV hash to the released tag 1.2.5. PV now carries the version directly and SRCREV references it, so the git fetcher resolves the 1.2.5 tag (which includes the WPE_BACKEND_LIBRARY change from entservices-runtime PR #37). This follows the same PV / SRCREV="${PV}" pattern used by entservices-infra.


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 490c76bd50de0759ac23dc89cc5d1e87289166e0
