### PR TITLE
RDKEMW-18677 - Auto PR for rdkcentral/meta-rdk-video 4154

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="a8f49eaaf0362cc39e8db3216b682ba39f9adcc7">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="3dc0008d76a6845e1014ef53f5b8d8c093e39d5e">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: RDKEMW-18677: Protect MediaCapabilities JS wrapper from GC

Add GenerateIsReachable=ReachableFromNavigator to prevent wrapper GC.
The MediaCapabilities interface is annotated [SameObject] in the spec,
meaning navigator.mediaCapabilities must return the same object on every
access. Without GC protection, the JS wrapper can be collected when no
JS reference holds it, causing a new wrapper to be created on next access.
This breaks object identity and loses any user-set properties.


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 3dc0008d76a6845e1014ef53f5b8d8c093e39d5e
