### PR TITLE
RDKEMW-19268 - Auto PR for rdkcentral/meta-middleware-generic-support 2988

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="cd1fc4ac96feb06e0f08c3d2af2f3e54bba6e4dd">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="483715c5e3ae74ec14c406a2c2ffa0ad7ee3978d">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: On processing a gst HDCP error, flush with teardown is called without stopping stream injection leading to an abort
Test Procedure: See ticket
Risks: low


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: 483715c5e3ae74ec14c406a2c2ffa0ad7ee3978d
