### PR TITLE
RDKEMW-19100 - Auto PR for rdkcentral/meta-rdk-video 4185

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="649facba1eb09c3b7bccd445923006ea3d165feb">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="3ec7629ba4b776b26fe0a9da58ae29011df84d8f">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: gstreamer-cleanup is happening on every reboot when /opt/cdl_flashed_file_name is missing. Fixing the issues as well as re-locating gstreamer-cleanup.service file to recipies-multimedia instead of sysint folder
Test Procedure: Boot the TV and check for gstreamer-cleanup metrics in rdk_milestones.log
Risks: low


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 3ec7629ba4b776b26fe0a9da58ae29011df84d8f
