### PR TITLE
RDKEMW-18793 - Auto PR for rdkcentral/meta-middleware-generic-support 2978

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="f2eda68ab0b39270e1aac390a64a6d81cf3758e5">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="3a059e9ef20437d9fd832e7b73d09741b4da384f">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: gstreamer-cleanup is happening on every reboot when /opt/cdl_flashed_file_name is missing. Fixing the issues as well as re-locating gstreamer-cleanup.service file to recipes-multimedia instead of sysint folder
Test Procedure: Boot the TV and check for gstreamer-cleanup metrics in rdk_milestones.log
Risks: low


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: 3a059e9ef20437d9fd832e7b73d09741b4da384f
