### PR TITLE
RDKEMW-18818 - Auto PR for rdkcentral/meta-rdk 925

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -6,12 +6,12 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
-  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="6a339b0e3c3eb43226f91d3da5f890d7aa901ad6">
+  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="1d01dbc1a92a686bd27a465525447d668de5e1bc">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_RDK" />
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="3453cc486369f5c49591ac14d50fd90d3201978b">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="1cf855e05df78eb4d27d905e60cc33fe92f5d8f5">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: Reason for change - The NTP servers are configured using the server directive in chrony.conf. With this configuration, DNS resolution occurs only once during startup, and Chrony selects one of the resolved IP addresses. If the selected address is an IPv6 address, Chrony sends NTP requests to the server, but no response is received.

Configure the NTP servers using the pool directive instead of the server directive. The pool directive performs periodic DNS re-resolution of the configured hostnames, allowing Chrony to select alternate addresses when needed, which effectively mitigates the issue.


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk, Merge Commit SHA: 1d01dbc1a92a686bd27a465525447d668de5e1bc
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 1cf855e05df78eb4d27d905e60cc33fe92f5d8f5
