### PR TITLE
NO-TICKET - Auto PR for rdkcentral/meta-rdk-video 4398

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="2e88eb660011832da53fc0610636af4e5de9c030">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="4f54f619d2c5f25fb9a6651e508b184c31e83042">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: Reason for Change: NetworkManager release v3.3.0 with following fixes
Fixed the memory leak that caused by the persistent m_nmClient.
Test Procedure: NA
Priority:P1
Risks: Medium


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 4f54f619d2c5f25fb9a6651e508b184c31e83042
