### PR TITLE
RDKEMW-19048 - Auto PR for rdkcentral/meta-rdk-video 4172

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="460befdcf17dbca9bbd8dc469a641ac30d83faa7">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="14375b7dfd36617344eccf7268e656f9fea409cd">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: Finalization PR for the RDKEMW-19048 deep-sleep SecAPI handle set on develop.

Three commits:

1. **wpeframework-clientlibraries r4.4 patch** - `0002-RDKEMW-19048-Release-and-reacquire-Vault-SecProcessor-for-deep-sleep.patch`, a squash of the former 0002 wrapper patch (this PR's original content) and the 0003 reacquire patch (#4297, now closed). Verified to produce a byte-identical patched tree to applying the two originals in sequence. Adds `vault_processor_release()` C wrapper for the CryptographyExtAccess plugin, and reacquires the SecProcessor at Vault method entry so cached `VaultImplementation*` holders do not crash after release.
2. **entservices-cryptography 1.0.2 -> 1.0.5** (SRCREV `d95807fac4b50ae036aeb1486b0be0dc3142ea93`) - 1.0.5 carries entservices-cryptography#12 (release Vault singleton SecProcessor handle on deep sleep). Intermediate 1.0.3/1.0.4 are CI-workflow/header changes only.
3. **thunderstartupservices 1.3.6 -> 1.3.9** (SRCREV `a46ca7149fabe6e441903bea4ecf8bf937ca5efa`) - 1.3.9 carries thunder-startup-services#240 (order org.rdk.Cryptography activation after org.rdk.PowerManager). 1.3.7/1.3.8 in between bring a packagemanager unit tweak and the new appactions unit (RDKEMW-17106).

DevQA builds (MW `middleware-dbg/RDKEMW-19048-5`, all five arch feeds) carry exactly this content; rootfs content-verified on Sky Llama Panel and XiOne Xfinity Stream Box images.

Version: patch

Resolves rdkcentral/meta-rdk-video#4400


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 14375b7dfd36617344eccf7268e656f9fea409cd
