### PR TITLE
RDK-60535 - Auto PR for rdkcentral/meta-rdk-video 4338

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="c080402a4317172ca919475af8f5198edb2cefb9">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="8c142066f1174a3b85d56a2d05e8f028095bb95b">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: Upgrade wpe-webkit src rev. Incomming changes:

 - Add env var to control whether the tile only the visible area of the layers: WPE_SIMPLIFIED_3D_COMPOSITION, WPE_TILE_VISIBLE_AREA_ONLY
 - Backport fixes for player suspend https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1682
 - HTML audio element currentTime property too high when setting srcObject to MediaStream https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1683
 - [GStreamer][WebAudio] Disallow RialtoMSEAudio in WebAudio
 - [GStreamer] webrtc/video-vp8-videorange.html is flaky failing https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1684

Change-Id: I905c5ecdd90aebc1ff09000c908d93295cf6d73e


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 8c142066f1174a3b85d56a2d05e8f028095bb95b
