### PR TITLE
RDKEMW-18836 - Auto PR for rdkcentral/meta-rdk-video 4193

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="aa6fed24b7a3c92f38032e30cf07aa72eb32d3eb">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="19aa224f30fbc4fddd8a7bef498dc0ecbe6f672c">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: Update entservices-monitor to 1.1.0. Its main feature is ability to configure the list of configured plugins from the recipe, using the PLUGIN_MONITOR_INSTANCES_LIST variable.
Cleaned up the recipe for a lot of unused and unsupported leftovers from plugin split (entservices-infra to individual projects). TextToSpeech configuration is now set in the recipe rather than in source code.



List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 19aa224f30fbc4fddd8a7bef498dc0ecbe6f672c
