### PR TITLE
RDKEMW-19730 - Auto PR for rdkcentral/meta-rdk-video 4442

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="dba47f98ce66586ba724fb41b8061ea22d1ad085">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="360c70373668fa82c270976c01de8e9578a00855">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: Revert VAD from ctrlm v1.1.17 and vsdk v1.0.14 since that requires an OSS release to include webrtc-audio-processing


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 360c70373668fa82c270976c01de8e9578a00855
