### PR TITLE
RDK-61847 - Auto PR for rdkcentral/meta-rdk-video 4637

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="ac8e95a3ace1db28dba65fb7230de8a2772411b8">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="075369a8882dd03be10ee099f7b16d7041933cea">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: RDK-61847: wpe-webkit 2.46.2 minor upgrade

Bring the latest WPEWebKit wpe-2.46 revision:
* Missing video in WebRTC playback when decoding on playback pipeline
* Additional H.264 encode profile/level advertisement.
* MediaCapabilities GC lifetime fix.
* WASM 64b build fix
* Canvas capture stream rendering and timing fixes in GStreamer path.

Remove obsolete wpe-webkit_2.46 base recipe.


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 075369a8882dd03be10ee099f7b16d7041933cea
