### PR TITLE
RDKEMW-21514 - Auto PR for rdkcentral/meta-rdk-video 4698

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -1,17 +1,17 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <manifest>
-  <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral"/>
+  <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
   <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="refs/tags/1.20.0">
-  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC"/>
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
   <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="refs/tags/1.20.0">
-  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_RDK"/>
-  <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE"/>
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_RDK" />
+  <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="refs/tags/1.20.0">
-  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO"/>
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="50b5b15d20d10efe4a5342cda31857f379a67c40">
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: Backport of the develop fix (RDKEMW-20680) to release/8.6.3.0.

release/8.6.3.0 carries the RDKEMW-19048 deep-sleep set but, like develop, shipped `vault_processor_release()` for the SecApi backend only. The shared CryptographyExtAccess plugin calls it unconditionally from `onPowerModeChanged`, so platforms that build the OpenSSL vault (RDKM community: RTK/BCM/RPI) fail to load the plugin with `undefined symbol: vault_processor_release` and cannot enter deep sleep. Release blocker for RDKM.

Adds a no-op `vault_processor_release()` to the OpenSSL and Thunder backends via `0003-RDKEMW-20680-vault-processor-release-openssl-thunder-stubs.patch`. Neither backend holds a SecAPI SecProcessor handle across S3, so the stub only satisfies the ABI so the plugin loads. SecApi keeps its real handle-releasing implementation (`0002-RDKEMW-19048-...`). Same change as develop.

Version: patch



List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 50b5b15d20d10efe4a5342cda31857f379a67c40
