### PR TITLE
RDKEMW-19501 - Auto PR for rdkcentral/meta-rdk-video 4728

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="fba1795900de109d72de6c8159bf203c9eef3425">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="f3e37f06a18920aa7e344fe157997651c789ac36">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: Reason for change:  Extend the advertised/accepted H.264 profile-level-id set to cover additional profile families and levels seen in offers, preventing WebRTC playback failures during SDP negotiation.
Test Procedure: Validate a sample app with multiple profile level family given in offer
Priority: P1
Risks: None


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: f3e37f06a18920aa7e344fe157997651c789ac36
