### PR TITLE
RDKEMW-20104 - Auto PR for rdkcentral/meta-rdk-video 4428

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="4aaf581038f5ad57af2a1dfa2b10453ce0d8a499">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="679fdd7e81a9f0645a45ba0b8a8d4a783c172ba1">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: Reason for change: gstreamer-cleanup is happening on every reboot when /opt/cdl_flashed_file_name is missing. Fixing the issues as well as re-locating gstreamer-cleanup.service file to recipies-multimedia instead of sysint folder
Test Procedure: Boot the TV and check for gstreamer-cleanup metrics in rdk_milestones.log
Risks: low


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 679fdd7e81a9f0645a45ba0b8a8d4a783c172ba1
