### PR TITLE
RDKEMW-20104 - Auto PR for rdkcentral/meta-middleware-generic-support 3031

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/rdkcentral" name="rdkcentral" review="https://github.com/rdkcentral" />
 
-  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="refs/tags/1.17.5">
+  <project groups="rdk" name="meta-middleware-generic-support" path="meta-middleware-generic-support" remote="rdkcentral" revision="e2c06b57b0227d0292ba124e33fd1c3b12157a8c">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 


### PR DESCRIPTION
Details: Reason for change: gstreamer-cleanup is happening on every reboot when /opt/cdl_flashed_file_name is missing. Fixing the issues as well as re-locating gstreamer-cleanup.service file to recipies-multimedia instead of sysint folder
Test Procedure: Boot the TV and check for gstreamer-cleanup metrics in rdk_milestones.log
Risks: low


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-middleware-generic-support, Merge Commit SHA: e2c06b57b0227d0292ba124e33fd1c3b12157a8c
