### PR TITLE
RDKEMW-20680 - Auto PR for rdkcentral/meta-rdk-video 4697

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="d90d94e221cc282a7ec0409614b6b4046d73d8e9">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="ee0613b8ff77261f8c1708036e1e95b26382aaf8">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: Follow-up to RDKEMW-19048. That change added `vault_processor_release()` to the SecApi vault backend only; the shared CryptographyExtAccess plugin (entservices-cryptography) calls the symbol unconditionally from `onPowerModeChanged`.

The cryptography library links exactly one backend (`CRYPTOGRAPHY_IMPLEMENTATION = enable_icrypto_openssl ? OpenSSL : SecApi`), so platforms that build the OpenSSL vault (RDKM community: RTK/BCM/RPI) fail to load the plugin with `undefined symbol: vault_processor_release` and cannot enter deep sleep.

Adds a no-op `vault_processor_release()` to the OpenSSL and Thunder backends via a new patch `0003-RDKEMW-20680-vault-processor-release-openssl-thunder-stubs.patch`. Neither backend holds a SecAPI SecProcessor handle across S3, so there is nothing to release - the stub only satisfies the ABI so the plugin loads. SecApi keeps its real handle-releasing implementation (`0002-RDKEMW-19048-...`).

Reported on RDKM (RTD1325); supersedes the dependency workaround in #4564.

Version: patch



List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: ee0613b8ff77261f8c1708036e1e95b26382aaf8
