### PR TITLE
RDKEMW-20646 - Auto PR for rdkcentral/meta-rdk-video 4791

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="bc3b43ba868c4d50262096120f45b0b8ed5cf7b1">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="487fed16673dc6c5a12a9c78885bbe416a558ac7">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: Reason for change:  NetworkManager release v3.4.0 with following fixes
    -> Using dedicated Eventing thread to send the events (#322)
    -> Added telemetry T2 event posting for IPv6 public IP (#325)
    -> LegacyNetworkAPIs logs are not printed under wpeframework logs (#324)
    -> reconnect failure on deepsleep wakeup (#321)
    -> Fix the notification locks in networkmanager plugin (#319)


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 487fed16673dc6c5a12a9c78885bbe416a558ac7
