### PR TITLE
RDKEMW-21853 - Auto PR for rdkcentral/meta-rdk-video 4774

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="e2df25eae855069bb51018f48d78118fc99e57f1">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="d91c693b98f39e6fcdd6b700a9f95b95b708d926">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: Reason for change: Extend the advertised/accepted H.264 profile-level-id set to cover additional profile families and levels seen in offers, preventing WebRTC playback failures during SDP negotiation.
Test Procedure: Validate a sample app with multiple profile level family given in offer
Priority: P1
Risks: None


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: d91c693b98f39e6fcdd6b700a9f95b95b708d926
