### PR TITLE
RDKEVD-8621 : consume OSS 4.14.0 in Vendor - Amlogic

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -14,4 +14,8 @@
   <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="db710323bbb94e07a26ecb9d35c51a494f695e53">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
+
+  <project groups="layers" name="meta-rdk-bluetooth" path="meta-rdk-bluetooth" remote="rdkcentral" revision="refs/tags/1.1.0">
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_RDK_BLUETOOTH"/>
+  </project>
 </manifest>

--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -6,7 +6,7 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_MIDDLEWARE_DEV_GENERIC" />
   </project>
 
-  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="709fe5fdfe9682f30efd2e8b64a9fc583fe4f72f">
+  <project groups="rdk" name="meta-rdk" path="meta-rdk" remote="rdkcentral" revision="e309f212392b2ae6a481fafb2f0b7946066ccfee">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_RDK" />
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>

--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -19,3 +19,4 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_RDK_BLUETOOTH"/>
   </project>
 </manifest>
+


### PR DESCRIPTION
https://ccp.sys.comcast.net/browse/RDKEVD-8621
---
Need to add meta-rdk-bluetooth in middleware's submanifest rdke-middleware-generic-manifest/middleware-generic.xml ---
avoid following build issue
ERROR: lib32-bluetooth-core-1.0.11-r2 do_compile: oe_runmake failed ERROR: lib32-bluetooth-core-1.0.11-r2 do_compile: ExecutionError('/home/ubuntu/builds/rdk-e/rdk-yocto-gha-jobs/build-rdktv-us-armv8a/tmp-debug/work/rdktv-us-armv8a-middleware-rdkmllib32-linux-gnueabi/lib32-bluetooth-core/1.0.11-r2/temp/run.do_compile.3921300', 1, None, None)

| ../../git/src/btrCore_avMedia.c:52:10: fatal error: bluetooth/audio/a2dp-codecs.h: No such file or directory
|    52 | #include <bluetooth/audio/a2dp-codecs.h>
|       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
---