### PR TITLE
RDKEMW-22493 - Auto PR for rdkcentral/meta-rdk-video 4985

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="8cc90bd8643c44bb0af53e65b0f0b3ed006988b4">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="fe078b2ee1bb55dc37c6324dbd3aa9308aa5639b">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details:     Reason for change: The decryptToHost value was being pushed to the SVP context on every decrypt call, adding unnecessary per-frame overhead. Since it is set only once per pipeline and never changes, accept that a single update is sufficient and follow the established decrypt control flow for subsequent calls.

    Test Procedure: Launch a DRM-protected video (e.g. Netflix/Prime), play a video, switch content, and repeat playback about 10 times. Verify secure and decrypt-to-host playback both work correctly with no decryption failures.

    Risks: low
    Priority: P2


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: fe078b2ee1bb55dc37c6324dbd3aa9308aa5639b
