### PR TITLE
RDKEMW-16128 - Auto PR for rdkcentral/meta-rdk-video 4579

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="72f59e5c53859a4d79cb0ffb1d2b7ea8f33ed219">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="06f2c7d3569e4426d4be6b9bcb53e84f0a8736cf">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: **[WPEWebKit][libWebRTC][GStreamer] Missing video in WebRTC playback when decoding on playback pipeline**
Add a mechanism to keep undelivered webRTC frames when they come in an encoded format and there's no registered observer to deliver them to.
Redeliver the frames when the first observer is registered.
This solves the problem of missing WebRTC Video frames causing a black screen in cloud gaming.



List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 06f2c7d3569e4426d4be6b9bcb53e84f0a8736cf
