### PR TITLE
RDKEMW-23286 - Auto PR for rdkcentral/meta-rdk-video 5086

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="dbf4e0868655004245e1a0bbc7d4e93a9c9f55ae">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="0ed268f4fd72e4ea3c1eaed8a9be2fbe88d36aca">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: 
This pull request addresses a crash in WPE WebKit that occurs when a child
process dies before it can send its PID to the parent process. The main change
is to add a check for this scenario, preventing the parent from crashing and
handling the error gracefully instead. The patch is applied to the build, and
the logic in both the process launcher and IPC connection code is updated.

Crash handling improvements:

- Added a check in readPIDFromPeer (in ConnectionUnix.cpp) to return 0 if the
  child process dies before sending its PID (i.e., if recvmsg() returns 0),
  preventing a crash in the parent process. The parent now detects this
  condition and handles it gracefully.
- Updated ProcessLauncherGLib.cpp to handle a zero PID from readPIDFromPeer by
  stopping the socket monitor, closing the server socket, and emitting a crash
  signal, instead of aborting.

Build system changes:

- Added the new patch (1711.patch) to the SRC_URI in wpe-webkit_2.46.2.bb to
  ensure the fix is applied during the build process.

Upstream patch: WPEWebKit PR #1711
https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1711


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 0ed268f4fd72e4ea3c1eaed8a9be2fbe88d36aca
