### PR TITLE
RDKEMW-19470 - Auto PR for rdkcentral/meta-rdk-video 4924

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="adc33a0bea91ccc720cb2bc6a6906ed56e429c9f">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="2f4ce2c91761e95b99e5ab683473c4a3b42a506f">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 


### PR DESCRIPTION
Details: ## Summary

Builds on top of #4732. Adds two source patches to resolve a bitbake packaging clash where both `firebolt-native-transport` and `firebolt-cpp-transport` produce a shared library named `libFireboltTransport.so`, causing `do_package_write_ipk_setscene` to fail.

## Problem

`firebolt-native-transport` (AAMP/TTS) and `firebolt-cpp-transport` both use `project(FireboltTransport)` in their CMakeLists, producing identically named artifacts: `libFireboltTransport.so`, `libfirebolttransport1`, `libfirebolttransport-dbg`. Bitbake rejects the duplicate package files.

## Solution

Apply a source patch to `firebolt-cpp-transport` that renames the cmake project from `FireboltTransport` → `FireboltCppTransport`. This changes all downstream naming — the produced soname becomes `libFireboltCppTransport.so` and the cmake package name becomes `FireboltCppTransport`.

`firebolt-native-transport` is left completely untouched.

A companion patch updates `firebolt-cpp-client` to consume the renamed cmake package and link target.

## Changes

| File | What changed |
|---|---|
| `firebolt-cpp-transport.bb` | `SRC_URI` — apply soname rename patch |
| `files/0001-rename-soname-to-FireboltCppTransport.patch` | **New** — renames `project(FireboltTransport)` → `project(FireboltCppTransport)` in transport's CMakeLists.txt, cmake config template, and src/CMakeLists.txt |
| `firebolt-cpp-client.bb` | `SRC_URI` — apply consumer rename patch |
| `files/0001-rename-firebolttransport-lib.patch` | **New** — updates all `find_package`/`target_link_libraries` calls in client to use `FireboltCppTransport` |

## Testing

Both patches verified with `patch -p1 --dry-run` against the real release tarballs (v1.1.8 and v0.5.3) — all hunks apply cleanly with zero fuzz.

## Notes

- The soname patch is version-agnostic: the same three cmake locations are identical in v1.1.8, v1.1.10, and v1.1.11.
- Consumer-side changes (prime device layer) are tracked in the companion PR in `rdk-e/meta-rdk-comcast-video`.


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: 2f4ce2c91761e95b99e5ab683473c4a3b42a506f
