### PR TITLE
RDKEMW-23381 - Auto PR for rdkcentral/meta-rdk-video 5102

### DIFF
--- a/middleware-generic.xml
+++ b/middleware-generic.xml
@@ -11,7 +11,7 @@
   <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
   </project>
 
-  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="d7f5c84f3141f77defa2fb60831cd62bfbe922a9">
+  <project groups="rdk" name="meta-rdk-video" path="meta-rdk-video" remote="rdkcentral" revision="a5c1e54b41f31e39387726a0153fa0e31bfc5a56">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_RDK_VIDEO" />
   </project>
 </manifest>


### PR DESCRIPTION
Details: We have fixed the Playready Netflix playback failures on NTS test cases and then Widevine initial playback issues.



List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-rdk-video, Merge Commit SHA: a5c1e54b41f31e39387726a0153fa0e31bfc5a56
